### PR TITLE
Control hue lights

### DIFF
--- a/src/main/kotlin/com/larastudios/chambrier/adapter/hue/HueClient.kt
+++ b/src/main/kotlin/com/larastudios/chambrier/adapter/hue/HueClient.kt
@@ -5,10 +5,13 @@ import org.springframework.core.ParameterizedTypeReference
 import org.springframework.http.MediaType
 import org.springframework.http.codec.ServerSentEvent
 import org.springframework.stereotype.Service
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.support.WebClientAdapter
 import org.springframework.web.service.annotation.GetExchange
 import org.springframework.web.service.annotation.HttpExchange
+import org.springframework.web.service.annotation.PutExchange
 import org.springframework.web.service.invoker.HttpServiceProxyFactory
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
@@ -26,6 +29,8 @@ class HueClient(private val webClient: WebClient) {
     fun retrieveLights(): Mono<HueResponse<LightGet>> = service.lights()
 
     fun retrieveButtons(): Mono<HueResponse<ButtonGet>> = service.buttons()
+
+    fun controlLight(lightId: String, @RequestBody requestBody: LightRequest): Mono<String> = service.light(lightId, requestBody)
 
     fun sse(): Flux<ServerSentEvent<List<SseData>>> {
         val type = object : ParameterizedTypeReference<ServerSentEvent<List<SseData>>>() {}
@@ -46,6 +51,9 @@ class HueClient(private val webClient: WebClient) {
 
         @GetExchange("/light")
         fun lights(): Mono<HueResponse<LightGet>>
+
+        @PutExchange("/light/{lightId}")
+        fun light(@PathVariable lightId: String, @RequestBody requestBody: LightRequest): Mono<String>
 
         @GetExchange("/button")
         fun buttons(): Mono<HueResponse<ButtonGet>>

--- a/src/main/kotlin/com/larastudios/chambrier/adapter/hue/HueController.kt
+++ b/src/main/kotlin/com/larastudios/chambrier/adapter/hue/HueController.kt
@@ -34,9 +34,7 @@ class HueController(val client: HueClient) : Controller {
                     is DecrementNumberValue -> currentValue - propertyValue.value
                     else -> null
                 }?.let {
-                    val minimumValue = brightnessProperty.minimum?.toDouble() ?: Double.MIN_VALUE
-                    val maximumValue = brightnessProperty.maximum?.toDouble() ?: Double.MAX_VALUE
-                    val value = it.toDouble().coerceIn(minimumValue, maximumValue)
+                    val value = it.coerceInNullable(brightnessProperty.minimum, brightnessProperty.maximum)
 
                     logger.info { "Change property '${brightnessProperty.name}' of device '${device.name}' to '$value' from '$currentValue'..." }
                     SetDimming(brightness = value)

--- a/src/main/kotlin/com/larastudios/chambrier/adapter/hue/HueController.kt
+++ b/src/main/kotlin/com/larastudios/chambrier/adapter/hue/HueController.kt
@@ -1,0 +1,40 @@
+package com.larastudios.chambrier.adapter.hue
+
+import com.larastudios.chambrier.app.Controller
+import com.larastudios.chambrier.app.domain.*
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.stereotype.Service
+
+@Service
+class HueController(val client: HueClient) : Controller {
+    override fun send(commands: List<DeviceCommand>) {
+        commands.filterIsInstance<ControlDeviceCommand>().forEach(::send)
+    }
+
+    private fun send(command: ControlDeviceCommand) {
+        logger.info { "Sending command $command" }
+        val device = command.device
+
+        if (device.type == DeviceType.Light) {
+            val onProperty = device.properties.values.firstOrNull { it.type == PropertyType.On } as? BooleanProperty
+            val on = onProperty?.let {
+                when (val propertyValue = command.propertyMap[it.name]) {
+                    is SetBooleanValue -> On(propertyValue.value)
+                    is ToggleBooleanValue -> On(!it.value)
+                    else -> null
+                }?.apply { logger.info { "Change property '${onProperty.name}' of device '${device.name}' to '$on' from '${onProperty.value}'..." } }
+            }
+
+            if (on != null) {
+                client.controlLight(onProperty.externalId!!, LightRequest(on = on))
+                    .log()
+                    .subscribe()
+            }
+        }
+    }
+
+
+    companion object {
+        private val logger = KotlinLogging.logger {}
+    }
+}

--- a/src/main/kotlin/com/larastudios/chambrier/adapter/hue/HueController.kt
+++ b/src/main/kotlin/com/larastudios/chambrier/adapter/hue/HueController.kt
@@ -41,8 +41,16 @@ class HueController(val client: HueClient) : Controller {
                 }
             }
 
-            if (onProperty != null && (on != null || brightness != null)) {
-                client.controlLight(onProperty.externalId!!, LightRequest(on = on, dimming = brightness))
+            val colorProperty = device.properties.values.firstOrNull { it.type == PropertyType.Color } as? ColorProperty
+            val color = colorProperty?.let {
+                val propertyValue = command.propertyMap[it.name] as? SetColorValue
+                propertyValue?.let {
+                    SetColor(xy = it.xy)
+                }
+            }?.apply { logger.info { "Change property '${colorProperty.name}' of device '${device.name}' to '$xy' from '${colorProperty.xy}'..." } }
+
+            if (onProperty != null && (on != null || brightness != null || color != null)) {
+                client.controlLight(onProperty.externalId!!, LightRequest(on = on, dimming = brightness, color = color))
                     .log()
                     .subscribe()
             }

--- a/src/main/kotlin/com/larastudios/chambrier/adapter/hue/HueController.kt
+++ b/src/main/kotlin/com/larastudios/chambrier/adapter/hue/HueController.kt
@@ -27,11 +27,11 @@ class HueController(val client: HueClient) : Controller {
 
             val brightnessProperty = device.properties.values.firstOrNull { it.type == PropertyType.Brightness } as? NumberProperty
             val brightness = brightnessProperty?.let {
-                val currentValue = brightnessProperty.value?.toDouble() ?: 0.0
+                val currentValue = brightnessProperty.value ?: 0
                 when (val propertyValue = command.propertyMap[it.name]) {
                     is SetNumberValue -> propertyValue.value
-                    is IncrementNumberValue -> currentValue + propertyValue.value.toDouble()
-                    is DecrementNumberValue -> currentValue - propertyValue.value.toDouble()
+                    is IncrementNumberValue -> currentValue + propertyValue.value
+                    is DecrementNumberValue -> currentValue - propertyValue.value
                     else -> null
                 }?.let {
                     val minimumValue = brightnessProperty.minimum?.toDouble() ?: Double.MIN_VALUE

--- a/src/main/kotlin/com/larastudios/chambrier/adapter/hue/KelvinConversions.kt
+++ b/src/main/kotlin/com/larastudios/chambrier/adapter/hue/KelvinConversions.kt
@@ -1,4 +1,8 @@
 package com.larastudios.chambrier.adapter.hue
 
+import com.larastudios.chambrier.app.domain.div
+
 // See https://en.wikipedia.org/wiki/Mired
 fun mirekToKelvin(mirek: Int) = 1_000_000 / mirek
+
+fun kelvinToMirek(kelvin: Number) = 1_000_000 / kelvin

--- a/src/main/kotlin/com/larastudios/chambrier/adapter/hue/LightRequest.kt
+++ b/src/main/kotlin/com/larastudios/chambrier/adapter/hue/LightRequest.kt
@@ -12,7 +12,7 @@ data class LightRequest(
 )
 
 data class SetDimming(
-    val brightness: Int, // >= 0 && <= 100
+    val brightness: Number, // >= 0 && <= 100
 )
 
 data class SetColorTemperature(

--- a/src/main/kotlin/com/larastudios/chambrier/adapter/hue/LightRequest.kt
+++ b/src/main/kotlin/com/larastudios/chambrier/adapter/hue/LightRequest.kt
@@ -1,0 +1,22 @@
+package com.larastudios.chambrier.adapter.hue
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonInclude.*
+
+@JsonInclude(Include.NON_NULL)
+data class LightRequest(
+    val on: On? = null,
+    val dimming: SetDimming? = null,
+    val colorTemperature: SetColorTemperature? = null,
+    val color: SetColor? = null,
+)
+
+data class SetDimming(
+    val brightness: Int, // >= 0 && <= 100
+)
+
+data class SetColorTemperature(
+    val mirek: Int, // >= 153 && <= 500
+)
+
+data class SetColor(val xy: Xy)

--- a/src/main/kotlin/com/larastudios/chambrier/adapter/hue/LightRequest.kt
+++ b/src/main/kotlin/com/larastudios/chambrier/adapter/hue/LightRequest.kt
@@ -17,7 +17,7 @@ data class SetDimming(
 )
 
 data class SetColorTemperature(
-    val mirek: Int, // >= 153 && <= 500
+    val mirek: Number, // >= 153 && <= 500
 )
 
 data class SetColor(val xy: CartesianCoordinate)

--- a/src/main/kotlin/com/larastudios/chambrier/adapter/hue/LightRequest.kt
+++ b/src/main/kotlin/com/larastudios/chambrier/adapter/hue/LightRequest.kt
@@ -2,6 +2,7 @@ package com.larastudios.chambrier.adapter.hue
 
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonInclude.*
+import com.larastudios.chambrier.app.domain.CartesianCoordinate
 
 @JsonInclude(Include.NON_NULL)
 data class LightRequest(
@@ -19,4 +20,4 @@ data class SetColorTemperature(
     val mirek: Int, // >= 153 && <= 500
 )
 
-data class SetColor(val xy: Xy)
+data class SetColor(val xy: CartesianCoordinate)

--- a/src/main/kotlin/com/larastudios/chambrier/adapter/hue/sse/MapLightChanged.kt
+++ b/src/main/kotlin/com/larastudios/chambrier/adapter/hue/sse/MapLightChanged.kt
@@ -1,5 +1,6 @@
 package com.larastudios.chambrier.adapter.hue.sse
 
+import com.larastudios.chambrier.adapter.hue.mirekToKelvin
 import com.larastudios.chambrier.app.domain.*
 
 fun mapChangedLightProperty(property: ChangedLightProperty): Sequence<Event> = sequence {
@@ -24,6 +25,6 @@ fun mapChangedLightProperty(property: ChangedLightProperty): Sequence<Event> = s
     }
 
     if (property.colorTemperature != null) {
-        yield(NumberPropertyChanged(property.owner.rid, "colorTemperature", property.colorTemperature.mirek))
+        yield(NumberPropertyChanged(property.owner.rid, "colorTemperature", mirekToKelvin(property.colorTemperature.mirek)))
     }
 }

--- a/src/main/kotlin/com/larastudios/chambrier/app/AppListener.kt
+++ b/src/main/kotlin/com/larastudios/chambrier/app/AppListener.kt
@@ -1,6 +1,7 @@
 package com.larastudios.chambrier.app
 
 import com.larastudios.chambrier.app.domain.ControlDeviceCommand
+import com.larastudios.chambrier.app.domain.FlowContext
 import com.larastudios.chambrier.app.flowEngine.ControlDeviceAction
 import com.larastudios.chambrier.app.flowEngine.FlowEngine
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -22,8 +23,8 @@ class AppListener(
         val flows = flowLoader.load()
 
         store.state()
-            .doOnNext {
-                val commands = flows.map(flowEngine::execute)
+            .doOnNext { state ->
+                val commands = flows.map { flowEngine.execute(it, FlowContext(state)) }
                     .map {
                         getCommandMap(it.scope)
                     }

--- a/src/main/kotlin/com/larastudios/chambrier/app/AppListener.kt
+++ b/src/main/kotlin/com/larastudios/chambrier/app/AppListener.kt
@@ -29,7 +29,10 @@ class AppListener(
                         getCommandMap(it.scope)
                     }
                     .fold(mapOf(), ::mergeCommandMaps)
-                    .map { (deviceId, propertyMap) -> ControlDeviceCommand(deviceId, propertyMap) }
+                    .map { (deviceId, propertyMap) ->
+                        val device = state.devices[deviceId] ?: throw IllegalArgumentException("State contains no device with id '$deviceId'")
+                        ControlDeviceCommand(device, propertyMap)
+                    }
 
                 controllers.forEach {
                     it.send(commands)

--- a/src/main/kotlin/com/larastudios/chambrier/app/PropertyChangedReducer.kt
+++ b/src/main/kotlin/com/larastudios/chambrier/app/PropertyChangedReducer.kt
@@ -72,11 +72,6 @@ class PropertyChangedReducer : Reducer {
                 return state
             }
 
-            if (property.readonly) {
-                logger.warn { "Unable to modify read-only property '${event.propertyId}' for device '${device.id}' (${device.name}): $event" }
-                return state
-            }
-
             val updatedProperty = map(property)
             return State.devices.index(Index.map(), device.id)
                 .properties.index(Index.map(), property.name)

--- a/src/main/kotlin/com/larastudios/chambrier/app/domain/DeviceCommands.kt
+++ b/src/main/kotlin/com/larastudios/chambrier/app/domain/DeviceCommands.kt
@@ -3,6 +3,6 @@ package com.larastudios.chambrier.app.domain
 interface DeviceCommand
 
 data class ControlDeviceCommand(
-    val deviceId: String,
+    val device: Device,
     val propertyMap: Map<String, PropertyValue>
 ) : DeviceCommand

--- a/src/main/kotlin/com/larastudios/chambrier/app/domain/FlowContext.kt
+++ b/src/main/kotlin/com/larastudios/chambrier/app/domain/FlowContext.kt
@@ -1,0 +1,7 @@
+package com.larastudios.chambrier.app.domain
+
+import com.larastudios.chambrier.app.flowEngine.Context
+
+data class FlowContext(
+    val state: State
+) : Context

--- a/src/main/kotlin/com/larastudios/chambrier/app/domain/NumberOperators.kt
+++ b/src/main/kotlin/com/larastudios/chambrier/app/domain/NumberOperators.kt
@@ -56,5 +56,13 @@ operator fun Number.minus(other: Number): Number = when (this) {
     else -> throws()
 }
 
+// Must have a different name than coerceIn to prevent recursive calls
+fun Number.coerceInNullable(minimumValue: Number?, maximumValue: Number?): Number = when (this) {
+    is Int -> this.coerceIn(minimumValue?.toInt(), maximumValue?.toInt())
+    is Long -> this.coerceIn(minimumValue?.toLong(), maximumValue?.toLong())
+    is Double -> this.coerceIn(minimumValue?.toDouble(), maximumValue?.toDouble())
+    else -> throws()
+}
+
 @Suppress("NOTHING_TO_INLINE")
 private inline fun throws(): Nothing = throw UnsupportedOperationException("Unsupported number type")

--- a/src/main/kotlin/com/larastudios/chambrier/app/domain/NumberOperators.kt
+++ b/src/main/kotlin/com/larastudios/chambrier/app/domain/NumberOperators.kt
@@ -56,6 +56,34 @@ operator fun Number.minus(other: Number): Number = when (this) {
     else -> throws()
 }
 
+operator fun Number.div(other: Number): Number = when (this) {
+    is Int -> {
+        when (other) {
+            is Int -> this / other
+            is Long -> this / other
+            is Double -> this / other
+            else -> throws()
+        }
+    }
+    is Long -> {
+        when (other) {
+            is Int -> this / other
+            is Long -> this / other
+            is Double -> this / other
+            else -> throws()
+        }
+    }
+    is Double -> {
+        when (other) {
+            is Int -> this / other
+            is Long -> this / other
+            is Double -> this / other
+            else -> throws()
+        }
+    }
+    else -> throws()
+}
+
 // Must have a different name than coerceIn to prevent recursive calls
 fun Number.coerceInNullable(minimumValue: Number?, maximumValue: Number?): Number = when (this) {
     is Int -> this.coerceIn(minimumValue?.toInt(), maximumValue?.toInt())

--- a/src/main/kotlin/com/larastudios/chambrier/app/domain/NumberOperators.kt
+++ b/src/main/kotlin/com/larastudios/chambrier/app/domain/NumberOperators.kt
@@ -1,0 +1,60 @@
+package com.larastudios.chambrier.app.domain
+
+operator fun Number.plus(other: Number): Number = when (this) {
+    is Int -> {
+        when (other) {
+            is Int -> this + other
+            is Long -> this + other
+            is Double -> this + other
+            else -> throws()
+        }
+    }
+    is Long -> {
+        when (other) {
+            is Int -> this + other
+            is Long -> this + other
+            is Double -> this + other
+            else -> throws()
+        }
+    }
+    is Double -> {
+        when (other) {
+            is Int -> this + other
+            is Long -> this + other
+            is Double -> this + other
+            else -> throws()
+        }
+    }
+    else -> throws()
+}
+
+operator fun Number.minus(other: Number): Number = when (this) {
+    is Int -> {
+        when (other) {
+            is Int -> this - other
+            is Long -> this - other
+            is Double -> this - other
+            else -> throws()
+        }
+    }
+    is Long -> {
+        when (other) {
+            is Int -> this - other
+            is Long -> this - other
+            is Double -> this - other
+            else -> throws()
+        }
+    }
+    is Double -> {
+        when (other) {
+            is Int -> this - other
+            is Long -> this - other
+            is Double -> this - other
+            else -> throws()
+        }
+    }
+    else -> throws()
+}
+
+@Suppress("NOTHING_TO_INLINE")
+private inline fun throws(): Nothing = throw UnsupportedOperationException("Unsupported number type")

--- a/src/main/kotlin/com/larastudios/chambrier/app/domain/Properties.kt
+++ b/src/main/kotlin/com/larastudios/chambrier/app/domain/Properties.kt
@@ -2,7 +2,7 @@ package com.larastudios.chambrier.app.domain
 
 import arrow.optics.optics
 
-interface Property {
+sealed interface Property {
     val name: String
     val type: PropertyType
     val readonly: Boolean

--- a/src/main/kotlin/com/larastudios/chambrier/app/domain/PropertyValues.kt
+++ b/src/main/kotlin/com/larastudios/chambrier/app/domain/PropertyValues.kt
@@ -24,7 +24,6 @@ data class DecrementNumberValue(
 
 data class SetColorValue(
     val xy: CartesianCoordinate,
-    val gamut: Gamut?,
 ) : AbsolutePropertyValue
 
 data class SetEnumValue<T: Enum<T>>(

--- a/src/main/kotlin/com/larastudios/chambrier/app/domain/PropertyValues.kt
+++ b/src/main/kotlin/com/larastudios/chambrier/app/domain/PropertyValues.kt
@@ -1,6 +1,6 @@
 package com.larastudios.chambrier.app.domain
 
-interface PropertyValue
+sealed interface PropertyValue
 interface AbsolutePropertyValue : PropertyValue
 interface RelativePropertyValue : PropertyValue
 
@@ -30,3 +30,10 @@ data class SetColorValue(
 data class SetEnumValue<T: Enum<T>>(
     val value: T,
 ) : AbsolutePropertyValue
+
+fun PropertyValue.isAssignableTo(property: Property): Boolean = when (property) {
+    is BooleanProperty -> this is SetBooleanValue || this is ToggleBooleanValue
+    is NumberProperty -> this is SetNumberValue || this is IncrementNumberValue || this is DecrementNumberValue
+    is ColorProperty -> this is SetColorValue
+    is EnumProperty<*> -> this is SetEnumValue<*>
+}

--- a/src/main/kotlin/com/larastudios/chambrier/app/flowEngine/Actions.kt
+++ b/src/main/kotlin/com/larastudios/chambrier/app/flowEngine/Actions.kt
@@ -1,0 +1,73 @@
+package com.larastudios.chambrier.app.flowEngine
+
+import com.larastudios.chambrier.app.domain.Device
+import com.larastudios.chambrier.app.domain.FlowContext
+import com.larastudios.chambrier.app.domain.PropertyValue
+import com.larastudios.chambrier.app.domain.isAssignableTo
+import io.github.oshai.kotlinlogging.KotlinLogging
+
+interface Action {
+    fun execute(context: Context, scope: Scope)
+}
+
+data object DoNothingAction : Action {
+    override fun execute(context: Context, scope: Scope) {}
+}
+
+data class LogAction(val message: String) : Action {
+    override fun execute(context: Context, scope: Scope) {
+        logger.info { message }
+    }
+
+    companion object {
+        private val logger = KotlinLogging.logger {}
+    }
+}
+
+data class ControlDeviceAction(val deviceId: String, val propertyMap: Map<String, PropertyValue>) : Action {
+    override fun execute(context: Context, scope: Scope) {
+        val state = (context as FlowContext).state
+        val device = state.devices[deviceId]
+        if (device == null) {
+            logger.warn { "Unable to control unknown device '$deviceId', ignoring control device action: $propertyMap" }
+            return
+        }
+        val filteredPropertyMap = filterInvalidProperties(propertyMap, device)
+        if (filteredPropertyMap.isEmpty()) {
+            return
+        }
+
+        val commandMap: MutableMap<String, Map<String, PropertyValue>> = getCommandMap(scope.data) ?: mutableMapOf()
+        commandMap.compute(deviceId) { _, currentValue ->
+            currentValue?.plus(filteredPropertyMap) ?: filteredPropertyMap
+        }
+
+        scope.data[COMMAND_MAP] = commandMap
+    }
+
+    private fun filterInvalidProperties(propertyMap: Map<String, PropertyValue>, device: Device): Map<String, PropertyValue> =
+        propertyMap.filter { (propertyId, propertyValue) ->
+            val property = device.properties[propertyId]
+            if (property == null) {
+                logger.warn { "Unable to set value of unknown property '$propertyId' for device '${device.id}' (${device.name})" }
+                false
+            } else if (property.readonly) {
+                logger.warn { "Unable to modify read-only property '$propertyId' for device '${device.id}' (${device.name})" }
+                false
+            } else {
+                val isAssignable = propertyValue.isAssignableTo(property)
+                if (!isAssignable) {
+                    logger.warn { "Incompatible property types: property '$propertyId' of device '${device.id}' (${device.name}) is of type '${property::class.simpleName}', but the value is of type '${propertyValue::class.simpleName}'" }
+                }
+                isAssignable
+            }
+        }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun getCommandMap(data: MutableMap<String, Any>): MutableMap<String, Map<String, PropertyValue>>? = data[COMMAND_MAP] as? MutableMap<String, Map<String, PropertyValue>>
+
+    companion object {
+        private val logger = KotlinLogging.logger {}
+        const val COMMAND_MAP = "_commandMap"
+    }
+}

--- a/src/main/kotlin/com/larastudios/chambrier/app/flowEngine/Context.kt
+++ b/src/main/kotlin/com/larastudios/chambrier/app/flowEngine/Context.kt
@@ -1,0 +1,11 @@
+package com.larastudios.chambrier.app.flowEngine
+
+/**
+ * The context should be an immutable data class that describes the context in
+ * which the flow is executed. It could contain the current user, the
+ * permissions that can be used, the data the flow can use but not modify.
+ *
+ * Data that should be stored and passed to other nodes should be stored in the
+ * [Scope].
+ */
+interface Context

--- a/src/main/kotlin/com/larastudios/chambrier/app/flowEngine/Flow.kt
+++ b/src/main/kotlin/com/larastudios/chambrier/app/flowEngine/Flow.kt
@@ -45,15 +45,15 @@ data class ActionFlowNode(
 
 
 interface Action {
-    fun execute(scope: Scope)
+    fun execute(context: Context, scope: Scope)
 }
 
 data object DoNothingAction : Action {
-    override fun execute(scope: Scope) {}
+    override fun execute(context: Context, scope: Scope) {}
 }
 
 data class LogAction(val message: String) : Action {
-    override fun execute(scope: Scope) {
+    override fun execute(context: Context, scope: Scope) {
         logger.info { message }
     }
 
@@ -63,7 +63,7 @@ data class LogAction(val message: String) : Action {
 }
 
 data class ControlDeviceAction(val deviceId: String, val property: Map<String, PropertyValue>): Action {
-    override fun execute(scope: Scope) {
+    override fun execute(context: Context, scope: Scope) {
         val commandMap: MutableMap<String, Map<String, PropertyValue>> = getCommandMap(scope.data) ?: mutableMapOf()
         commandMap.compute(deviceId) { _, currentValue ->
             currentValue?.plus(property) ?: property

--- a/src/main/kotlin/com/larastudios/chambrier/app/flowEngine/Flow.kt
+++ b/src/main/kotlin/com/larastudios/chambrier/app/flowEngine/Flow.kt
@@ -89,6 +89,9 @@ data class ControlDeviceAction(val deviceId: String, val propertyMap: Map<String
             if (property == null) {
                 logger.warn { "Unable to set value of unknown property '$propertyId' for device '${device.id}' (${device.name})" }
                 false
+            } else if (property.readonly) {
+                logger.warn { "Unable to modify read-only property '$propertyId' for device '${device.id}' (${device.name})" }
+                false
             } else {
                 val isAssignable = propertyValue.isAssignableTo(property)
                 if (!isAssignable) {

--- a/src/main/kotlin/com/larastudios/chambrier/app/flowEngine/Flow.kt
+++ b/src/main/kotlin/com/larastudios/chambrier/app/flowEngine/Flow.kt
@@ -1,8 +1,6 @@
 package com.larastudios.chambrier.app.flowEngine
 
-import com.larastudios.chambrier.app.domain.*
 import com.larastudios.chambrier.app.flowEngine.expression.Expression
-import io.github.oshai.kotlinlogging.KotlinLogging
 
 data class Flow(
     val name: String,
@@ -42,70 +40,3 @@ data class ActionFlowNode(
     override val outgoingNodes: List<FlowLink>,
     val action: Action
 ) : FlowNode
-
-
-interface Action {
-    fun execute(context: Context, scope: Scope)
-}
-
-data object DoNothingAction : Action {
-    override fun execute(context: Context, scope: Scope) {}
-}
-
-data class LogAction(val message: String) : Action {
-    override fun execute(context: Context, scope: Scope) {
-        logger.info { message }
-    }
-
-    companion object {
-        private val logger = KotlinLogging.logger {}
-    }
-}
-
-data class ControlDeviceAction(val deviceId: String, val propertyMap: Map<String, PropertyValue>) : Action {
-    override fun execute(context: Context, scope: Scope) {
-        val state = (context as FlowContext).state
-        val device = state.devices[deviceId]
-        if (device == null) {
-            logger.warn { "Unable to control unknown device '$deviceId', ignoring control device action: $propertyMap" }
-            return
-        }
-        val filteredPropertyMap = filterInvalidProperties(propertyMap, device)
-        if (filteredPropertyMap.isEmpty()) {
-            return
-        }
-
-        val commandMap: MutableMap<String, Map<String, PropertyValue>> = getCommandMap(scope.data) ?: mutableMapOf()
-        commandMap.compute(deviceId) { _, currentValue ->
-            currentValue?.plus(filteredPropertyMap) ?: filteredPropertyMap
-        }
-
-        scope.data[COMMAND_MAP] = commandMap
-    }
-
-    private fun filterInvalidProperties(propertyMap: Map<String, PropertyValue>, device: Device): Map<String, PropertyValue> =
-        propertyMap.filter { (propertyId, propertyValue) ->
-            val property = device.properties[propertyId]
-            if (property == null) {
-                logger.warn { "Unable to set value of unknown property '$propertyId' for device '${device.id}' (${device.name})" }
-                false
-            } else if (property.readonly) {
-                logger.warn { "Unable to modify read-only property '$propertyId' for device '${device.id}' (${device.name})" }
-                false
-            } else {
-                val isAssignable = propertyValue.isAssignableTo(property)
-                if (!isAssignable) {
-                    logger.warn { "Incompatible property types: property '$propertyId' of device '${device.id}' (${device.name}) is of type '${property::class.simpleName}', but the value is of type '${propertyValue::class.simpleName}'" }
-                }
-                isAssignable
-            }
-        }
-
-    @Suppress("UNCHECKED_CAST")
-    private fun getCommandMap(data: MutableMap<String, Any>): MutableMap<String, Map<String, PropertyValue>>? = data[COMMAND_MAP] as? MutableMap<String, Map<String, PropertyValue>>
-
-    companion object {
-        private val logger = KotlinLogging.logger {}
-        const val COMMAND_MAP = "_commandMap"
-    }
-}

--- a/src/main/kotlin/com/larastudios/chambrier/app/flowEngine/FlowEngine.kt
+++ b/src/main/kotlin/com/larastudios/chambrier/app/flowEngine/FlowEngine.kt
@@ -1,5 +1,5 @@
 package com.larastudios.chambrier.app.flowEngine
 
 interface FlowEngine {
-    fun execute(flow: Flow): ExecutedFlowReport
+    fun execute(flow: Flow, context: Context): ExecutedFlowReport
 }

--- a/src/main/kotlin/com/larastudios/chambrier/app/flowEngine/RiverEngine.kt
+++ b/src/main/kotlin/com/larastudios/chambrier/app/flowEngine/RiverEngine.kt
@@ -6,23 +6,23 @@ import java.time.Duration
 
 @Service
 class RiverEngine : FlowEngine {
-    override fun execute(flow: Flow): ExecutedFlowReport {
+    override fun execute(flow: Flow, context: Context): ExecutedFlowReport {
         logger.debug { "Executing flow ${flow.name}..." }
         val start = System.currentTimeMillis()
 
         val scope = Scope(mutableMapOf())
-        executeNode(flow.startNode, scope)
+        executeNode(flow.startNode, context, scope)
 
         val durationInMs = System.currentTimeMillis() - start
         logger.debug { "Executing flow ${flow.name}... OK, took ${durationInMs}ms" }
         return ExecutedFlowReport(scope.data, Duration.ofMillis(durationInMs))
     }
 
-    private tailrec fun executeNode(node: FlowNode, scope: Scope) {
+    private tailrec fun executeNode(node: FlowNode, context: Context, scope: Scope) {
         val nextNode = when (node) {
             is ActionFlowNode -> {
                 logger.debug { "Executing action ${node.action::class.simpleName}" }
-                node.action.execute(scope)
+                node.action.execute(context, scope)
                 node.outgoingNodes.first().node
             }
             is ConditionalFlowNode -> {
@@ -37,7 +37,7 @@ class RiverEngine : FlowEngine {
 
         logger.debug { "Next node: ${nextNode.id}" }
         if (nextNode !is EndFlowNode) {
-            executeNode(nextNode, scope)
+            executeNode(nextNode, context, scope)
         }
     }
 

--- a/src/test/kotlin/com/larastudios/chambrier/DeviceFixtures.kt
+++ b/src/test/kotlin/com/larastudios/chambrier/DeviceFixtures.kt
@@ -10,7 +10,12 @@ val lightDevice = Device(
     "LWA021",
     "Hue filament bulb",
     "Livingroom",
-    mapOf())
+    mapOf(
+        booleanProperty.name to booleanProperty,
+        numberProperty.name to numberProperty,
+        colorProperty.name to colorProperty,
+    )
+)
 
 val lightDevice2 = Device(
     "39e84c3a-be8e-4eac-88dc-48baa2ab271d",
@@ -19,7 +24,37 @@ val lightDevice2 = Device(
     "LOM001",
     "Hue Smart plug",
     "Plug",
-    mapOf()
+    mapOf(
+        booleanProperty.name to booleanProperty,
+        numberProperty.name to numberProperty,
+        colorProperty.name to colorProperty,
+    )
 )
 
 val renamedLightDevice = lightDevice.copy(name = "Bedroom")
+
+val editableSwitchDevice = Device(
+    "5f679dab-db82-42a7-9e2c-de8040373689",
+    DeviceType.Switch,
+    "Signify Netherlands B.V.",
+    "RWL021",
+    "Hue dimmer switch",
+    "Kitchen",
+    mapOf("button" to enumProperty)
+)
+
+val switchDevice = Device(
+    "5f679dab-db82-42a7-9e2c-de8040373689",
+    DeviceType.Switch,
+    "Signify Netherlands B.V.",
+    "RWL021",
+    "Hue dimmer switch",
+    "Kitchen",
+    mapOf(
+        "button1" to enumProperty.copy(name = "button1", readonly = true),
+        "button2" to enumProperty.copy(name = "button2", readonly = true),
+        "button3" to enumProperty.copy(name = "button3", readonly = true),
+        "button4" to enumProperty.copy(name = "button4", readonly = true),
+    )
+)
+

--- a/src/test/kotlin/com/larastudios/chambrier/DeviceFixtures.kt
+++ b/src/test/kotlin/com/larastudios/chambrier/DeviceFixtures.kt
@@ -44,7 +44,7 @@ val editableSwitchDevice = Device(
 )
 
 val switchDevice = Device(
-    "5f679dab-db82-42a7-9e2c-de8040373689",
+    "0a65707c-bf48-42e9-8eb5-9f9e5114cfa0",
     DeviceType.Switch,
     "Signify Netherlands B.V.",
     "RWL021",

--- a/src/test/kotlin/com/larastudios/chambrier/PropertyFixtures.kt
+++ b/src/test/kotlin/com/larastudios/chambrier/PropertyFixtures.kt
@@ -1,0 +1,14 @@
+package com.larastudios.chambrier
+
+import com.larastudios.chambrier.app.domain.*
+import com.larastudios.chambrier.app.domain.Unit
+
+val booleanProperty = BooleanProperty("on", PropertyType.On, readonly = false, value = true)
+val numberProperty = NumberProperty("brightness", PropertyType.Brightness, readonly = false, Unit.Percentage, 42, null, null)
+val gamut = Gamut(
+    red = CartesianCoordinate(0.1, 0.2),
+    green = CartesianCoordinate(0.3, 0.4),
+    blue = CartesianCoordinate(0.5, 0.6),
+)
+val colorProperty = ColorProperty("color", PropertyType.Color, readonly = false, xy = CartesianCoordinate(0.01, 0.05), gamut = gamut)
+val enumProperty = EnumProperty("button", PropertyType.Button, readonly = false, values = HueButtonState.entries.toList(), value = HueButtonState.InitialPress)

--- a/src/test/kotlin/com/larastudios/chambrier/StateFixtures.kt
+++ b/src/test/kotlin/com/larastudios/chambrier/StateFixtures.kt
@@ -1,0 +1,12 @@
+package com.larastudios.chambrier
+
+import com.larastudios.chambrier.app.domain.State
+
+val initialState = State(
+    devices = mapOf(
+        lightDevice.id to lightDevice,
+        lightDevice2.id to lightDevice2,
+        switchDevice.id to switchDevice,
+        editableSwitchDevice.id to editableSwitchDevice,
+    )
+)

--- a/src/test/kotlin/com/larastudios/chambrier/adapter/hue/KelvinConversionsTest.kt
+++ b/src/test/kotlin/com/larastudios/chambrier/adapter/hue/KelvinConversionsTest.kt
@@ -15,4 +15,13 @@ class KelvinConversionsTest {
     fun `returns the value in Kelvin`(mirek: Int, kelvin: Int) {
         Assertions.assertThat(mirekToKelvin(mirek)).isEqualTo(kelvin)
     }
+
+    @ParameterizedTest(name = "{0} kelvin = {1} mirek")
+    @CsvSource(
+        "6535, 153",
+        "2000, 500"
+    )
+    fun `returns the value in mirek`(kelvin: Int, mirek: Int) {
+        Assertions.assertThat(kelvinToMirek(kelvin)).isEqualTo(mirek)
+    }
 }

--- a/src/test/kotlin/com/larastudios/chambrier/app/PropertyChangedReducerTest.kt
+++ b/src/test/kotlin/com/larastudios/chambrier/app/PropertyChangedReducerTest.kt
@@ -1,8 +1,7 @@
 package com.larastudios.chambrier.app
 
+import com.larastudios.chambrier.*
 import com.larastudios.chambrier.app.domain.*
-import com.larastudios.chambrier.app.domain.Unit
-import com.larastudios.chambrier.lightDevice
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
@@ -10,55 +9,35 @@ import org.junit.jupiter.api.Test
 
 @DisplayName("PropertyChangedReducer")
 class PropertyChangedReducerTest {
-    private val booleanProperty = BooleanProperty("on", PropertyType.On, readonly = false, value = true)
-    private val numberProperty = NumberProperty("brightness", PropertyType.Brightness, readonly = false, Unit.Percentage, 42, null, null)
-    private val gamut = Gamut(
-        red = CartesianCoordinate(0.1, 0.2),
-        green = CartesianCoordinate(0.3, 0.4),
-        blue = CartesianCoordinate(0.5, 0.6),
-    )
-    private val colorProperty = ColorProperty("color", PropertyType.Color, readonly = false, xy = CartesianCoordinate(0.01, 0.05), gamut = gamut)
-    private val enumProperty = EnumProperty("button", PropertyType.Button, readonly = false, values = HueButtonState.entries.toList(), value =  HueButtonState.InitialPress)
-
-    private val device: Device = lightDevice.copy(
-        properties = mapOf(
-            booleanProperty.name to booleanProperty,
-            numberProperty.name to numberProperty,
-            colorProperty.name to colorProperty,
-            enumProperty.name to enumProperty,
-        )
-    )
-    private val initialState: State = State(mapOf(device.id to device))
-
     @Test
     fun `reduces BooleanPropertyChanged by updating the device's property`() {
-        val event = BooleanPropertyChanged(device.id, booleanProperty.name, false)
+        val event = BooleanPropertyChanged(lightDevice.id, booleanProperty.name, false)
         val newState = PropertyChangedReducer().reduce(event, initialState)
 
         assertThat(newState.devices)
-            .extractingByKey(device.id)
+            .extractingByKey(lightDevice.id)
             .extracting { it.properties[booleanProperty.name] }
             .isEqualTo(BooleanProperty("on", PropertyType.On, readonly = false, value = false))
     }
 
     @Test
     fun `reduces NumberPropertyChanged by updating the device's property`() {
-        val event = NumberPropertyChanged(device.id, numberProperty.name, 1337)
+        val event = NumberPropertyChanged(lightDevice.id, numberProperty.name, 1337)
         val newState = PropertyChangedReducer().reduce(event, initialState)
 
         assertThat(newState.devices)
-            .extractingByKey(device.id)
+            .extractingByKey(lightDevice.id)
             .extracting { it.properties[numberProperty.name] }
             .isEqualTo(numberProperty.copy(value = 1337))
     }
 
     @Test
     fun `reduces ColorPropertyChanged without gamut by updating the device's property`() {
-        val event = ColorPropertyChanged(device.id, colorProperty.name, CartesianCoordinate(0.90, 0.91), null)
+        val event = ColorPropertyChanged(lightDevice.id, colorProperty.name, CartesianCoordinate(0.90, 0.91), null)
         val newState = PropertyChangedReducer().reduce(event, initialState)
 
         assertThat(newState.devices)
-            .extractingByKey(device.id)
+            .extractingByKey(lightDevice.id)
             .extracting { it.properties[colorProperty.name] }
             .isEqualTo(colorProperty.copy(xy = CartesianCoordinate(0.90, 0.91), gamut = null))
     }
@@ -70,33 +49,33 @@ class PropertyChangedReducerTest {
             green = CartesianCoordinate(0.82, 0.83),
             blue = CartesianCoordinate(0.84, 0.85),
         )
-        val event = ColorPropertyChanged(device.id, colorProperty.name, CartesianCoordinate(0.90, 0.91), gamut)
+        val event = ColorPropertyChanged(lightDevice.id, colorProperty.name, CartesianCoordinate(0.90, 0.91), gamut)
         val newState = PropertyChangedReducer().reduce(event, initialState)
 
         assertThat(newState.devices)
-            .extractingByKey(device.id)
+            .extractingByKey(lightDevice.id)
             .extracting { it.properties[colorProperty.name] }
             .isEqualTo(colorProperty.copy(xy = CartesianCoordinate(0.90, 0.91), gamut = gamut))
     }
 
     @Test
     fun `reduces EnumPropertyChanged by updating the device's property`() {
-        val event = EnumPropertyChanged(device.id, enumProperty.name, HueButtonState.ShortRelease)
+        val event = EnumPropertyChanged(editableSwitchDevice.id, enumProperty.name, HueButtonState.ShortRelease)
         val newState = PropertyChangedReducer().reduce(event, initialState)
 
         assertThat(newState.devices)
-            .extractingByKey(device.id)
+            .extractingByKey(editableSwitchDevice.id)
             .extracting { it.properties[enumProperty.name] }
             .isEqualTo(enumProperty.copy(value = HueButtonState.ShortRelease))
     }
 
     @Test
     fun `ignores EnumPropertyChanged by returning the unmodified state if the enum types do not match`() {
-        val event = EnumPropertyChanged(device.id, enumProperty.name, DifferentEnum.NotCool)
+        val event = EnumPropertyChanged(editableSwitchDevice.id, enumProperty.name, DifferentEnum.NotCool)
         val newState = PropertyChangedReducer().reduce(event, initialState)
 
         assertThat(newState.devices)
-            .extractingByKey(device.id)
+            .extractingByKey(editableSwitchDevice.id)
             .extracting { it.properties[enumProperty.name] }
             .isEqualTo(enumProperty)
     }
@@ -111,7 +90,7 @@ class PropertyChangedReducerTest {
 
     @Test
     fun `ignores the event by returning the unmodified state for a known device but an unknown property`() {
-        val event = NumberPropertyChanged(device.id, "unknown", 1337)
+        val event = NumberPropertyChanged(lightDevice.id, "unknown", 1337)
         val newState = PropertyChangedReducer().reduce(event, initialState)
 
         assertThat(newState).isEqualTo(initialState)

--- a/src/test/kotlin/com/larastudios/chambrier/app/PropertyChangedReducerTest.kt
+++ b/src/test/kotlin/com/larastudios/chambrier/app/PropertyChangedReducerTest.kt
@@ -97,19 +97,6 @@ class PropertyChangedReducerTest {
     }
 
     @Test
-    fun `ignores the event by returning the unmodified state for read-only property`() {
-        val device: Device = lightDevice.copy(
-            properties = mapOf(numberProperty.name to numberProperty.copy(readonly = true))
-        )
-        val initialState = State(mapOf(device.id to device))
-
-        val event = NumberPropertyChanged(device.id, numberProperty.name, 1337)
-        val newState = PropertyChangedReducer().reduce(event, initialState)
-
-        assertThat(newState).isEqualTo(initialState)
-    }
-
-    @Test
     fun `ignores other events by returning the unmodified state`() {
         val event = mockk<Event>()
         val newState = PropertyChangedReducer().reduce(event, initialState)

--- a/src/test/kotlin/com/larastudios/chambrier/app/domain/NumberOperatorsTest.kt
+++ b/src/test/kotlin/com/larastudios/chambrier/app/domain/NumberOperatorsTest.kt
@@ -1,0 +1,61 @@
+package com.larastudios.chambrier.app.domain
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import kotlin.reflect.KClass
+
+@DisplayName("NumberOperators")
+class NumberOperatorsTest {
+    @ParameterizedTest(name = "{0} + {1} = {2} (type: {3})")
+    @MethodSource("plusNumbersProvider")
+    fun `+ operator`(one: Number, two: Number, expected: Number, type: KClass<Any>) {
+        val actual = one + two
+
+        assertThat(actual).isEqualTo(expected)
+        assertThat(actual::class).isEqualTo(type)
+    }
+
+    @ParameterizedTest(name = "{0} - {1} = {2} (type: {3})")
+    @MethodSource("minusNumbersProvider")
+    fun `- operator`(one: Number, two: Number, expected: Number, type: KClass<Any>) {
+        val actual = one - two
+
+        assertThat(actual).isEqualTo(expected)
+        assertThat(actual::class).isEqualTo(type)
+    }
+
+    companion object {
+        @JvmStatic
+        fun plusNumbersProvider(): List<Arguments> = listOf(
+            Arguments.of(2, 3, 5, Int::class),
+            Arguments.of(2, 3L, 5L, Long::class),
+            Arguments.of(2, 3.1, 5.1, Double::class),
+
+            Arguments.of(2L, 3, 5L, Long::class),
+            Arguments.of(2L, 3L, 5L, Long::class),
+            Arguments.of(2L, 3.1, 5.1, Double::class),
+
+            Arguments.of(2.0, 3, 5.0, Double::class),
+            Arguments.of(2.0, 3L, 5.0, Double::class),
+            Arguments.of(2.0, 3.1, 5.1, Double::class),
+        )
+
+        @JvmStatic
+        fun minusNumbersProvider(): List<Arguments> = listOf(
+            Arguments.of(4, 3, 1, Int::class),
+            Arguments.of(4, 3L, 1L, Long::class),
+            Arguments.of(4, 3.0, 1.0, Double::class),
+
+            Arguments.of(4L, 3, 1L, Long::class),
+            Arguments.of(4L, 3L, 1L, Long::class),
+            Arguments.of(4L, 3.0, 1.0, Double::class),
+
+            Arguments.of(4.0, 3, 1.0, Double::class),
+            Arguments.of(4.0, 3L, 1.0, Double::class),
+            Arguments.of(4.0, 3.0, 1.0, Double::class),
+        )
+    }
+}

--- a/src/test/kotlin/com/larastudios/chambrier/app/domain/NumberOperatorsTest.kt
+++ b/src/test/kotlin/com/larastudios/chambrier/app/domain/NumberOperatorsTest.kt
@@ -27,17 +27,28 @@ class NumberOperatorsTest {
         assertThat(actual::class).isEqualTo(type)
     }
 
+    @ParameterizedTest(name = "{0}.coerceInNullable({1}, {2}) = {3}")
+    @MethodSource("coerceNumbersProvider")
+    fun coerceInNullable(value: Number, minimum: Number, maximum: Number, expected: Number) {
+        val actual = value.coerceInNullable(minimum, maximum)
+
+        assertThat(actual).isEqualTo(expected)
+    }
+
     companion object {
         @JvmStatic
         fun plusNumbersProvider(): List<Arguments> = listOf(
+            // Int
             Arguments.of(2, 3, 5, Int::class),
             Arguments.of(2, 3L, 5L, Long::class),
             Arguments.of(2, 3.1, 5.1, Double::class),
 
+            // Long
             Arguments.of(2L, 3, 5L, Long::class),
             Arguments.of(2L, 3L, 5L, Long::class),
             Arguments.of(2L, 3.1, 5.1, Double::class),
 
+            // Double
             Arguments.of(2.0, 3, 5.0, Double::class),
             Arguments.of(2.0, 3L, 5.0, Double::class),
             Arguments.of(2.0, 3.1, 5.1, Double::class),
@@ -45,17 +56,38 @@ class NumberOperatorsTest {
 
         @JvmStatic
         fun minusNumbersProvider(): List<Arguments> = listOf(
+            /// Int
             Arguments.of(4, 3, 1, Int::class),
             Arguments.of(4, 3L, 1L, Long::class),
             Arguments.of(4, 3.0, 1.0, Double::class),
 
+            // Long
             Arguments.of(4L, 3, 1L, Long::class),
             Arguments.of(4L, 3L, 1L, Long::class),
             Arguments.of(4L, 3.0, 1.0, Double::class),
 
+            // Double
             Arguments.of(4.0, 3, 1.0, Double::class),
             Arguments.of(4.0, 3L, 1.0, Double::class),
             Arguments.of(4.0, 3.0, 1.0, Double::class),
+        )
+
+        @JvmStatic
+        fun coerceNumbersProvider(): List<Arguments> = listOf(
+            // Int
+            Arguments.of(42, 0, 100, 42),
+            Arguments.of(42, 50, 100, 50),
+            Arguments.of(42, 0, 41, 41),
+
+            // Long
+            Arguments.of(42L, 0L, 100L, 42L),
+            Arguments.of(42L, 50L, 100L, 50L),
+            Arguments.of(42L, 0L, 41L, 41L),
+
+            // Double
+            Arguments.of(42.0, 0.0, 100.0, 42.0),
+            Arguments.of(42.0, 50.0, 100.0, 50.0),
+            Arguments.of(42.0, 0.0, 41.0, 41.0),
         )
     }
 }

--- a/src/test/kotlin/com/larastudios/chambrier/app/domain/NumberOperatorsTest.kt
+++ b/src/test/kotlin/com/larastudios/chambrier/app/domain/NumberOperatorsTest.kt
@@ -27,6 +27,15 @@ class NumberOperatorsTest {
         assertThat(actual::class).isEqualTo(type)
     }
 
+    @ParameterizedTest(name = "{0} / {1} = {2} (type: {3})")
+    @MethodSource("divNumbersProvider")
+    fun `div operator`(one: Number, two: Number, expected: Number, type: KClass<Any>) {
+        val actual = one / two
+
+        assertThat(actual).isEqualTo(expected)
+        assertThat(actual::class).isEqualTo(type)
+    }
+
     @ParameterizedTest(name = "{0}.coerceInNullable({1}, {2}) = {3}")
     @MethodSource("coerceNumbersProvider")
     fun coerceInNullable(value: Number, minimum: Number, maximum: Number, expected: Number) {
@@ -70,6 +79,24 @@ class NumberOperatorsTest {
             Arguments.of(4.0, 3, 1.0, Double::class),
             Arguments.of(4.0, 3L, 1.0, Double::class),
             Arguments.of(4.0, 3.0, 1.0, Double::class),
+        )
+
+        @JvmStatic
+        fun divNumbersProvider(): List<Arguments> = listOf(
+            /// Int
+            Arguments.of(9, 3, 3, Int::class),
+            Arguments.of(9, 3L, 3L, Long::class),
+            Arguments.of(9, 3.0, 3.0, Double::class),
+
+            // Long
+            Arguments.of(9L, 3, 3L, Long::class),
+            Arguments.of(9L, 3L, 3L, Long::class),
+            Arguments.of(9L, 3.0, 3.0, Double::class),
+
+            // Double
+            Arguments.of(9.0, 3, 3.0, Double::class),
+            Arguments.of(9.0, 3L, 3.0, Double::class),
+            Arguments.of(9.0, 3.0, 3.0, Double::class),
         )
 
         @JvmStatic

--- a/src/test/kotlin/com/larastudios/chambrier/app/domain/PropertyValuesTest.kt
+++ b/src/test/kotlin/com/larastudios/chambrier/app/domain/PropertyValuesTest.kt
@@ -1,0 +1,39 @@
+package com.larastudios.chambrier.app.domain
+
+import com.larastudios.chambrier.booleanProperty
+import com.larastudios.chambrier.colorProperty
+import com.larastudios.chambrier.enumProperty
+import com.larastudios.chambrier.numberProperty
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Named
+import org.junit.jupiter.api.Named.named
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+
+@DisplayName("PropertyValue")
+class PropertyValuesTest {
+
+    @ParameterizedTest(name = "{0} isAssignableTo({1}) = {2}")
+    @MethodSource("propertyValueProvider")
+    fun isAssignableTo(propertyValue: PropertyValue, property: Property, expected: Boolean) {
+        val actual = propertyValue.isAssignableTo(property)
+        assertThat(expected).isEqualTo(actual)
+    }
+
+    companion object {
+        @JvmStatic
+        fun propertyValueProvider(): List<Arguments> = listOf(
+            Arguments.of(SetBooleanValue(true).toNamed(), booleanProperty.toNamed(), true),
+            Arguments.of(ToggleBooleanValue.toNamed(), booleanProperty.toNamed(), true),
+            Arguments.of(SetNumberValue(42).toNamed(), numberProperty.toNamed(), true),
+            Arguments.of(IncrementNumberValue(5).toNamed(), numberProperty.toNamed(), true),
+            Arguments.of(DecrementNumberValue(3).toNamed(), numberProperty.toNamed(), true),
+            Arguments.of(SetColorValue(CartesianCoordinate(1.0, 1.0), null).toNamed(), colorProperty.toNamed(), true),
+            Arguments.of(SetEnumValue(HueButtonState.LongPress), enumProperty.toNamed(), true),
+        )
+
+        private inline fun <reified T> T.toNamed(): Named<T> = named(T::class.simpleName, this)
+    }
+}

--- a/src/test/kotlin/com/larastudios/chambrier/app/domain/PropertyValuesTest.kt
+++ b/src/test/kotlin/com/larastudios/chambrier/app/domain/PropertyValuesTest.kt
@@ -30,7 +30,7 @@ class PropertyValuesTest {
             Arguments.of(SetNumberValue(42).toNamed(), numberProperty.toNamed(), true),
             Arguments.of(IncrementNumberValue(5).toNamed(), numberProperty.toNamed(), true),
             Arguments.of(DecrementNumberValue(3).toNamed(), numberProperty.toNamed(), true),
-            Arguments.of(SetColorValue(CartesianCoordinate(1.0, 1.0), null).toNamed(), colorProperty.toNamed(), true),
+            Arguments.of(SetColorValue(CartesianCoordinate(1.0, 1.0)).toNamed(), colorProperty.toNamed(), true),
             Arguments.of(SetEnumValue(HueButtonState.LongPress), enumProperty.toNamed(), true),
         )
 

--- a/src/test/kotlin/com/larastudios/chambrier/app/flowEngine/ControlDeviceActionTest.kt
+++ b/src/test/kotlin/com/larastudios/chambrier/app/flowEngine/ControlDeviceActionTest.kt
@@ -1,7 +1,9 @@
 package com.larastudios.chambrier.app.flowEngine
 
+import com.larastudios.chambrier.app.domain.FlowContext
 import com.larastudios.chambrier.app.domain.IncrementNumberValue
 import com.larastudios.chambrier.app.domain.SetBooleanValue
+import com.larastudios.chambrier.app.domain.State
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -12,12 +14,13 @@ class ControlDeviceActionTest {
     private val propertyTwo = mapOf("brightness" to IncrementNumberValue(1))
     private val propertyThree = mapOf("on" to SetBooleanValue(false))
     private val action = ControlDeviceAction("42", property)
+    private val context = FlowContext(state = State(devices = mapOf()))
 
     @Test
     fun `adds the deviceId and properties if the command map is absent from the scope`() {
         val scope = Scope()
 
-        action.execute(scope)
+        action.execute(context, scope)
 
         assertThat(scope.data).containsKey(ControlDeviceAction.COMMAND_MAP)
         assertThat(scope.data[ControlDeviceAction.COMMAND_MAP]).isEqualTo(mutableMapOf("42" to property))
@@ -27,7 +30,7 @@ class ControlDeviceActionTest {
     fun `adds the deviceId and properties if the command map contains another deviceId`() {
         val scope = Scope(data = mutableMapOf(ControlDeviceAction.COMMAND_MAP to mutableMapOf("1337" to property)))
 
-        action.execute(scope)
+        action.execute(context, scope)
 
         assertThat(scope.data).containsKey(ControlDeviceAction.COMMAND_MAP)
         assertThat(scope.data[ControlDeviceAction.COMMAND_MAP]).isEqualTo(
@@ -42,7 +45,7 @@ class ControlDeviceActionTest {
     fun `adds the properties if the command map contains the deviceId but with different properties`() {
         val scope = Scope(data = mutableMapOf(ControlDeviceAction.COMMAND_MAP to mutableMapOf("42" to propertyTwo)))
 
-        action.execute(scope)
+        action.execute(context, scope)
 
         assertThat(scope.data).containsKey(ControlDeviceAction.COMMAND_MAP)
         assertThat(scope.data[ControlDeviceAction.COMMAND_MAP]).isEqualTo(
@@ -59,7 +62,7 @@ class ControlDeviceActionTest {
     fun `overwrites existing properties if the command map contains the deviceId and properties`() {
         val scope = Scope(data = mutableMapOf(ControlDeviceAction.COMMAND_MAP to mutableMapOf("42" to propertyTwo)))
 
-        action.execute(scope)
+        action.execute(context, scope)
 
         assertThat(scope.data).containsKey(ControlDeviceAction.COMMAND_MAP)
         assertThat(scope.data[ControlDeviceAction.COMMAND_MAP]).isEqualTo(
@@ -77,7 +80,7 @@ class ControlDeviceActionTest {
         val scope = Scope(data = mutableMapOf(ControlDeviceAction.COMMAND_MAP to mutableMapOf("42" to property)))
 
         val action = ControlDeviceAction("42", propertyTwo + propertyThree)
-        action.execute(scope)
+        action.execute(context, scope)
 
         assertThat(scope.data).containsKey(ControlDeviceAction.COMMAND_MAP)
         assertThat(scope.data[ControlDeviceAction.COMMAND_MAP]).isEqualTo(

--- a/src/test/kotlin/com/larastudios/chambrier/app/flowEngine/ControlDeviceActionTest.kt
+++ b/src/test/kotlin/com/larastudios/chambrier/app/flowEngine/ControlDeviceActionTest.kt
@@ -1,8 +1,12 @@
 package com.larastudios.chambrier.app.flowEngine
 
-import com.larastudios.chambrier.app.domain.*
-import com.larastudios.chambrier.app.domain.Unit
+import com.larastudios.chambrier.app.domain.FlowContext
+import com.larastudios.chambrier.app.domain.IncrementNumberValue
+import com.larastudios.chambrier.app.domain.SetBooleanValue
+import com.larastudios.chambrier.app.domain.State
+import com.larastudios.chambrier.initialState
 import com.larastudios.chambrier.lightDevice
+import com.larastudios.chambrier.lightDevice2
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -12,11 +16,8 @@ class ControlDeviceActionTest {
     private val property = mapOf("on" to SetBooleanValue(true))
     private val propertyTwo = mapOf("brightness" to IncrementNumberValue(1))
     private val propertyThree = mapOf("on" to SetBooleanValue(false))
-    private val action = ControlDeviceAction("42", property)
-    private val context = FlowContext(state = State(devices = mapOf("42" to lightDevice.copy(properties = mapOf(
-        "on" to BooleanProperty("on", PropertyType.Button, readonly = false, true),
-        "brightness" to NumberProperty("brightness", PropertyType.Brightness, readonly = false, Unit.Percentage, 42, null, null)
-    )))))
+    private val action = ControlDeviceAction(lightDevice.id, property)
+    private val context = FlowContext(state = initialState)
 
     @Test
     fun `does not modify the scope if the device is unknown `() {
@@ -31,7 +32,7 @@ class ControlDeviceActionTest {
     fun `ignores all properties if the device is known but all properties are unknown`() {
         val scope = Scope()
 
-        val action = ControlDeviceAction("42", mapOf("unknownProperty" to SetBooleanValue(true)))
+        val action = ControlDeviceAction(lightDevice.id, mapOf("unknownProperty" to SetBooleanValue(true)))
         action.execute(context, scope)
 
         assertThat(scope.data).isEmpty()
@@ -41,11 +42,11 @@ class ControlDeviceActionTest {
     fun `adds the known properties while ignoring unknown properties`() {
         val scope = Scope()
 
-        val action = ControlDeviceAction("42", mapOf("unknownProperty" to SetBooleanValue(true)) + property)
+        val action = ControlDeviceAction(lightDevice.id, mapOf("unknownProperty" to SetBooleanValue(true)) + property)
         action.execute(context, scope)
 
         assertThat(scope.data).containsKey(ControlDeviceAction.COMMAND_MAP)
-        assertThat(scope.data[ControlDeviceAction.COMMAND_MAP]).isEqualTo(mutableMapOf("42" to property))
+        assertThat(scope.data[ControlDeviceAction.COMMAND_MAP]).isEqualTo(mutableMapOf(lightDevice.id to property))
     }
 
     @Test
@@ -55,34 +56,34 @@ class ControlDeviceActionTest {
         action.execute(context, scope)
 
         assertThat(scope.data).containsKey(ControlDeviceAction.COMMAND_MAP)
-        assertThat(scope.data[ControlDeviceAction.COMMAND_MAP]).isEqualTo(mutableMapOf("42" to property))
+        assertThat(scope.data[ControlDeviceAction.COMMAND_MAP]).isEqualTo(mutableMapOf(lightDevice.id to property))
     }
 
     @Test
     fun `adds the deviceId and properties if the command map contains another deviceId`() {
-        val scope = Scope(data = mutableMapOf(ControlDeviceAction.COMMAND_MAP to mutableMapOf("1337" to property)))
+        val scope = Scope(data = mutableMapOf(ControlDeviceAction.COMMAND_MAP to mutableMapOf(lightDevice2.id to property)))
 
         action.execute(context, scope)
 
         assertThat(scope.data).containsKey(ControlDeviceAction.COMMAND_MAP)
         assertThat(scope.data[ControlDeviceAction.COMMAND_MAP]).isEqualTo(
             mutableMapOf(
-                "42" to property,
-                "1337" to property,
+                lightDevice.id to property,
+                lightDevice2.id to property,
             )
         )
     }
 
     @Test
     fun `adds the properties if the command map contains the deviceId but with different properties`() {
-        val scope = Scope(data = mutableMapOf(ControlDeviceAction.COMMAND_MAP to mutableMapOf("42" to propertyTwo)))
+        val scope = Scope(data = mutableMapOf(ControlDeviceAction.COMMAND_MAP to mutableMapOf(lightDevice.id to propertyTwo)))
 
         action.execute(context, scope)
 
         assertThat(scope.data).containsKey(ControlDeviceAction.COMMAND_MAP)
         assertThat(scope.data[ControlDeviceAction.COMMAND_MAP]).isEqualTo(
             mutableMapOf(
-                "42" to mutableMapOf(
+                lightDevice.id to mutableMapOf(
                     "on" to SetBooleanValue(true),
                     "brightness" to IncrementNumberValue(1),
                 )
@@ -92,14 +93,14 @@ class ControlDeviceActionTest {
 
     @Test
     fun `overwrites existing properties if the command map contains the deviceId and properties`() {
-        val scope = Scope(data = mutableMapOf(ControlDeviceAction.COMMAND_MAP to mutableMapOf("42" to propertyTwo)))
+        val scope = Scope(data = mutableMapOf(ControlDeviceAction.COMMAND_MAP to mutableMapOf(lightDevice.id to propertyTwo)))
 
         action.execute(context, scope)
 
         assertThat(scope.data).containsKey(ControlDeviceAction.COMMAND_MAP)
         assertThat(scope.data[ControlDeviceAction.COMMAND_MAP]).isEqualTo(
             mutableMapOf(
-                "42" to mutableMapOf(
+                lightDevice.id to mutableMapOf(
                     "on" to SetBooleanValue(true),
                     "brightness" to IncrementNumberValue(1),
                 )
@@ -109,15 +110,15 @@ class ControlDeviceActionTest {
 
     @Test
     fun `overwrites existing properties and adds new properties`() {
-        val scope = Scope(data = mutableMapOf(ControlDeviceAction.COMMAND_MAP to mutableMapOf("42" to property)))
+        val scope = Scope(data = mutableMapOf(ControlDeviceAction.COMMAND_MAP to mutableMapOf(lightDevice.id to property)))
 
-        val action = ControlDeviceAction("42", propertyTwo + propertyThree)
+        val action = ControlDeviceAction(lightDevice.id, propertyTwo + propertyThree)
         action.execute(context, scope)
 
         assertThat(scope.data).containsKey(ControlDeviceAction.COMMAND_MAP)
         assertThat(scope.data[ControlDeviceAction.COMMAND_MAP]).isEqualTo(
             mutableMapOf(
-                "42" to mutableMapOf(
+                lightDevice.id to mutableMapOf(
                     "on" to SetBooleanValue(false),
                     "brightness" to IncrementNumberValue(1),
                 )

--- a/src/test/kotlin/com/larastudios/chambrier/app/flowEngine/ControlDeviceActionTest.kt
+++ b/src/test/kotlin/com/larastudios/chambrier/app/flowEngine/ControlDeviceActionTest.kt
@@ -1,9 +1,8 @@
 package com.larastudios.chambrier.app.flowEngine
 
-import com.larastudios.chambrier.app.domain.FlowContext
-import com.larastudios.chambrier.app.domain.IncrementNumberValue
-import com.larastudios.chambrier.app.domain.SetBooleanValue
-import com.larastudios.chambrier.app.domain.State
+import com.larastudios.chambrier.app.domain.*
+import com.larastudios.chambrier.app.domain.Unit
+import com.larastudios.chambrier.lightDevice
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -14,7 +13,40 @@ class ControlDeviceActionTest {
     private val propertyTwo = mapOf("brightness" to IncrementNumberValue(1))
     private val propertyThree = mapOf("on" to SetBooleanValue(false))
     private val action = ControlDeviceAction("42", property)
-    private val context = FlowContext(state = State(devices = mapOf()))
+    private val context = FlowContext(state = State(devices = mapOf("42" to lightDevice.copy(properties = mapOf(
+        "on" to BooleanProperty("on", PropertyType.Button, readonly = false, true),
+        "brightness" to NumberProperty("brightness", PropertyType.Brightness, readonly = false, Unit.Percentage, 42, null, null)
+    )))))
+
+    @Test
+    fun `does not modify the scope if the device is unknown `() {
+        val scope = Scope()
+
+        action.execute(FlowContext(State(mapOf())), scope)
+
+        assertThat(scope.data).isEmpty()
+    }
+
+    @Test
+    fun `ignores all properties if the device is known but all properties are unknown`() {
+        val scope = Scope()
+
+        val action = ControlDeviceAction("42", mapOf("unknownProperty" to SetBooleanValue(true)))
+        action.execute(context, scope)
+
+        assertThat(scope.data).isEmpty()
+    }
+
+    @Test
+    fun `adds the known properties while ignoring unknown properties`() {
+        val scope = Scope()
+
+        val action = ControlDeviceAction("42", mapOf("unknownProperty" to SetBooleanValue(true)) + property)
+        action.execute(context, scope)
+
+        assertThat(scope.data).containsKey(ControlDeviceAction.COMMAND_MAP)
+        assertThat(scope.data[ControlDeviceAction.COMMAND_MAP]).isEqualTo(mutableMapOf("42" to property))
+    }
 
     @Test
     fun `adds the deviceId and properties if the command map is absent from the scope`() {

--- a/src/test/kotlin/com/larastudios/chambrier/app/flowEngine/ControlDeviceActionTest.kt
+++ b/src/test/kotlin/com/larastudios/chambrier/app/flowEngine/ControlDeviceActionTest.kt
@@ -1,12 +1,10 @@
 package com.larastudios.chambrier.app.flowEngine
 
-import com.larastudios.chambrier.app.domain.FlowContext
-import com.larastudios.chambrier.app.domain.IncrementNumberValue
-import com.larastudios.chambrier.app.domain.SetBooleanValue
-import com.larastudios.chambrier.app.domain.State
+import com.larastudios.chambrier.app.domain.*
 import com.larastudios.chambrier.initialState
 import com.larastudios.chambrier.lightDevice
 import com.larastudios.chambrier.lightDevice2
+import com.larastudios.chambrier.switchDevice
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -33,6 +31,16 @@ class ControlDeviceActionTest {
         val scope = Scope()
 
         val action = ControlDeviceAction(lightDevice.id, mapOf("unknownProperty" to SetBooleanValue(true)))
+        action.execute(context, scope)
+
+        assertThat(scope.data).isEmpty()
+    }
+
+    @Test
+    fun `ignores valid properties that are read-only`() {
+        val scope = Scope()
+
+        val action = ControlDeviceAction(switchDevice.id, mapOf("button1" to SetEnumValue(HueButtonState.ShortRelease)))
         action.execute(context, scope)
 
         assertThat(scope.data).isEmpty()

--- a/src/test/kotlin/com/larastudios/chambrier/app/flowEngine/FlowFactoryTest.kt
+++ b/src/test/kotlin/com/larastudios/chambrier/app/flowEngine/FlowFactoryTest.kt
@@ -134,15 +134,7 @@ class FlowFactoryTest {
             "brightness" to SetNumberValue(50),
             "fanSpeed" to IncrementNumberValue(10),
             "turnSpeed" to DecrementNumberValue(8),
-            "color" to SetColorValue(CartesianCoordinate(0.1, 0.2), null),
-            "colorWithGamut" to SetColorValue(
-                CartesianCoordinate(0.3, 0.4),
-                Gamut(
-                    red = CartesianCoordinate(0.5, 0.6),
-                    green = CartesianCoordinate(0.7, 0.8),
-                    blue = CartesianCoordinate(0.9, 1.0),
-                ),
-            ),
+            "color" to SetColorValue(CartesianCoordinate(0.1, 0.2)),
             "button" to SetEnumValue(HueButtonState.ShortRelease)
         )
         val actionNode = ActionFlowNode("controlNode", listOf(FlowLink(endNode)), ControlDeviceAction("42", propertyMap))

--- a/src/test/kotlin/com/larastudios/chambrier/app/flowEngine/RiverEngineTest.kt
+++ b/src/test/kotlin/com/larastudios/chambrier/app/flowEngine/RiverEngineTest.kt
@@ -2,6 +2,7 @@ package com.larastudios.chambrier.app.flowEngine
 
 import com.larastudios.chambrier.app.domain.*
 import com.larastudios.chambrier.app.flowEngine.expression.*
+import com.larastudios.chambrier.lightDevice
 import io.mockk.*
 import org.assertj.core.api.Assertions.*
 import org.junit.jupiter.api.Test
@@ -84,6 +85,17 @@ class RiverEngineTest {
         val startNode = StartFlowNode("startNode", listOf(FlowLink(actionNode)))
         val flow = Flow("flow", listOf(), startNode)
 
+        val property = BooleanProperty("fan", PropertyType.Button, readonly = false, true)
+        val context = FlowContext(state = State(devices = mapOf("42" to lightDevice.copy(properties = mapOf(
+            "fan" to property,
+            "on" to property,
+            "brightness" to property,
+            "fanSpeed" to property,
+            "turnSpeed" to property,
+            "color" to property,
+            "colorWithGamut" to property,
+            "button" to property
+        )))))
         val report = engine.execute(flow, context)
 
         verify { actionSpy.execute(context, any<Scope>()) }

--- a/src/test/kotlin/com/larastudios/chambrier/app/flowEngine/RiverEngineTest.kt
+++ b/src/test/kotlin/com/larastudios/chambrier/app/flowEngine/RiverEngineTest.kt
@@ -69,15 +69,7 @@ class RiverEngineTest {
             "brightness" to SetNumberValue(50),
             "fanSpeed" to IncrementNumberValue(10),
             "turnSpeed" to DecrementNumberValue(8),
-            "color" to SetColorValue(CartesianCoordinate(0.1, 0.2), null),
-            "colorWithGamut" to SetColorValue(
-                CartesianCoordinate(0.3, 0.4),
-                Gamut(
-                    red = CartesianCoordinate(0.5, 0.6),
-                    green = CartesianCoordinate(0.7, 0.8),
-                    blue = CartesianCoordinate(0.9, 1.0),
-                ),
-            ),
+            "color" to SetColorValue(CartesianCoordinate(0.1, 0.2)),
             "button" to SetEnumValue(HueButtonState.ShortRelease)
         )
         val actionSpy = spyk(ControlDeviceAction("42", propertyMap))
@@ -92,7 +84,6 @@ class RiverEngineTest {
             "fanSpeed" to numberProperty,
             "turnSpeed" to numberProperty,
             "color" to colorProperty,
-            "colorWithGamut" to colorProperty,
             "button" to enumProperty
         )))))
         val report = engine.execute(flow, context)

--- a/src/test/kotlin/com/larastudios/chambrier/app/flowEngine/RiverEngineTest.kt
+++ b/src/test/kotlin/com/larastudios/chambrier/app/flowEngine/RiverEngineTest.kt
@@ -1,8 +1,8 @@
 package com.larastudios.chambrier.app.flowEngine
 
+import com.larastudios.chambrier.*
 import com.larastudios.chambrier.app.domain.*
 import com.larastudios.chambrier.app.flowEngine.expression.*
-import com.larastudios.chambrier.lightDevice
 import io.mockk.*
 import org.assertj.core.api.Assertions.*
 import org.junit.jupiter.api.Test
@@ -85,16 +85,15 @@ class RiverEngineTest {
         val startNode = StartFlowNode("startNode", listOf(FlowLink(actionNode)))
         val flow = Flow("flow", listOf(), startNode)
 
-        val property = BooleanProperty("fan", PropertyType.Button, readonly = false, true)
         val context = FlowContext(state = State(devices = mapOf("42" to lightDevice.copy(properties = mapOf(
-            "fan" to property,
-            "on" to property,
-            "brightness" to property,
-            "fanSpeed" to property,
-            "turnSpeed" to property,
-            "color" to property,
-            "colorWithGamut" to property,
-            "button" to property
+            "fan" to booleanProperty,
+            "on" to booleanProperty,
+            "brightness" to numberProperty,
+            "fanSpeed" to numberProperty,
+            "turnSpeed" to numberProperty,
+            "color" to colorProperty,
+            "colorWithGamut" to colorProperty,
+            "button" to enumProperty
         )))))
         val report = engine.execute(flow, context)
 

--- a/src/test/resources/flows/controlDeviceFlow.json
+++ b/src/test/resources/flows/controlDeviceFlow.json
@@ -37,15 +37,6 @@
             "type": "color",
             "xy": { "x": 0.1, "y": 0.2 }
           },
-          "colorWithGamut": {
-            "type": "color",
-            "xy": { "x": 0.3, "y": 0.4 },
-            "gamut": {
-              "red": { "x": 0.5, "y": 0.6 },
-              "green": { "x": 0.7, "y": 0.8 },
-              "blue": { "x": 0.9, "y": 1.0 }
-            }
-          },
           "button": {
             "type": "enum",
             "value": "HueButtonState.ShortRelease"


### PR DESCRIPTION
- Pass a context to a flow, which is an immutable view of the world in which the flow is executed
- `ControlDeviceAction` filters out devices and properties that are not known
- `ControlDeviceAction` filters out property values that cannot be assigned to the specified property
- Allow controlling Hue lights
- A read-only property can be set by an observer, but not from a flow
