### PR TITLE
Introduce coroutines

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,10 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")
 
+    // Coroutines
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.0-RC2")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor:1.8.0-RC2")
+
     // Arrow
     implementation("io.arrow-kt:arrow-core:1.2.0")
     implementation("io.arrow-kt:arrow-optics:1.2.0")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
     // Coroutines
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.0-RC2")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor:1.8.0-RC2")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.0-RC2")
 
     // Arrow
     implementation("io.arrow-kt:arrow-core:1.2.0")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,6 +31,11 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor:1.8.0-RC2")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.0-RC2")
 
+    // Resilience4j
+    implementation("io.github.resilience4j:resilience4j-spring-boot3:2.2.0")
+    implementation("io.github.resilience4j:resilience4j-ratelimiter:2.2.0")
+    implementation("io.github.resilience4j:resilience4j-kotlin:2.2.0")
+
     // Arrow
     implementation("io.arrow-kt:arrow-core:1.2.0")
     implementation("io.arrow-kt:arrow-optics:1.2.0")

--- a/src/main/kotlin/com/larastudios/chambrier/RateLimiterConfiguration.kt
+++ b/src/main/kotlin/com/larastudios/chambrier/RateLimiterConfiguration.kt
@@ -1,0 +1,12 @@
+package com.larastudios.chambrier
+
+import io.github.resilience4j.ratelimiter.RateLimiter
+import io.github.resilience4j.ratelimiter.RateLimiterRegistry
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class RateLimiterConfiguration {
+    @Bean
+    fun hueRatelimiter(registry: RateLimiterRegistry): RateLimiter = registry.rateLimiter("hue")
+}

--- a/src/main/kotlin/com/larastudios/chambrier/adapter/FileFlowLoader.kt
+++ b/src/main/kotlin/com/larastudios/chambrier/adapter/FileFlowLoader.kt
@@ -5,6 +5,8 @@ import com.larastudios.chambrier.app.FlowLoader
 import com.larastudios.chambrier.app.flowEngine.Flow
 import com.larastudios.chambrier.app.flowEngine.FlowFactory
 import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 import java.nio.file.Files
@@ -17,25 +19,27 @@ class FileFlowLoader(
     private val directory: String,
     private val factory: FlowFactory
 ) : FlowLoader {
-    override fun load(): List<Flow> {
+    override suspend fun load(): List<Flow> {
         logger.info { "Loading flows..." }
         val path = Paths.get(directory)
         if (!Files.isDirectory(path)) {
             throw FlowLoadException("Flows directory '$directory' is not a directory")
         }
 
-        val files = Files.newDirectoryStream(path, "*.json")
-            .use { it.toList() }
-            .mapNotNull {
-                logger.debug { "Loading flow ${it.fileName.name}" }
-                val json = Files.readString(it, Charsets.UTF_8)
-                try {
-                    factory.fromJson(json)
-                } catch (e: Exception) {
-                    logger.warn(e) { "Unable to load flow '${it}'" }
-                    null
+        val files = withContext(Dispatchers.IO) {
+            Files.newDirectoryStream(path, "*.json")
+                .use { it.toList() }
+                .mapNotNull {
+                    logger.debug { "Loading flow ${it.fileName.name}" }
+                    val json = Files.readString(it, Charsets.UTF_8)
+                    try {
+                        factory.fromJson(json)
+                    } catch (e: Exception) {
+                        logger.warn(e) { "Unable to load flow '${it}'" }
+                        null
+                    }
                 }
-            }
+        }
 
         logger.info { "Loading flows... OK, ${files.size} flow(s) loaded" }
         return files

--- a/src/main/kotlin/com/larastudios/chambrier/adapter/hue/HueObserver.kt
+++ b/src/main/kotlin/com/larastudios/chambrier/adapter/hue/HueObserver.kt
@@ -6,31 +6,37 @@ import com.larastudios.chambrier.app.Observer
 import com.larastudios.chambrier.app.domain.DiscoveredDevices
 import com.larastudios.chambrier.app.domain.Event
 import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.reactive.asFlow
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Service
 import reactor.core.publisher.Mono
-import reactor.kotlin.core.util.function.component1
-import reactor.kotlin.core.util.function.component2
-import reactor.kotlin.core.util.function.component3
 
 @Service
 @ConditionalOnProperty("hue.enabled")
 class HueObserver(val client: HueClient) : Observer {
-    override suspend fun observe(): Flow<Event> {
+    override suspend fun observe(): Flow<Event> = coroutineScope {
         logger.info { "Retrieve Hue devices..." }
-        val devices = client.retrieveDevices()
-            .flatMap { it.extractData("devices") }
-            .map { it.associateBy { device -> device.id } }
+        val deferredDevices = client.retrieveDevices()
 
         logger.info { "Retrieve Hue lights..." }
-        val lights = client.retrieveLights()
-            .flatMap { it.extractData("lights") }
+        val deferredLights = client.retrieveLights()
 
         logger.info { "Retrieve Hue switches..." }
-        val buttons = client.retrieveButtons()
-            .flatMap { it.extractData("switches") }
+        val deferredButtons = client.retrieveButtons()
+
+        awaitAll(deferredDevices, deferredLights, deferredButtons)
+
+        val devices = deferredDevices.await()
+            .extractData("devices")
+            .associateBy { device -> device.id }
+        val lights = deferredLights.await().extractData("lights")
+        val buttons = deferredButtons.await().extractData("switches")
+
+        val lightDevices = mapLights(lights, devices)
+        val switchDevices = mapSwitches(buttons, devices)
 
         val sseStream = client.sse()
         val eventStream = sseStream
@@ -55,26 +61,20 @@ class HueObserver(val client: HueClient) : Observer {
             }
             .flatMapIterable { it }
 
-        return Mono.zip(devices, lights, buttons)
-            .map { (deviceMap, lights, buttons) ->
-                val lightDevices = mapLights(lights, deviceMap)
-                val switchDevices = mapSwitches(buttons, deviceMap)
-
-                lightDevices + switchDevices
-            }
-            .map<Event> { DiscoveredDevices(it) }
+        val event: Event = DiscoveredDevices(lightDevices + switchDevices)
+        Mono.just(event)
             .concatWith(eventStream)
             .asFlow()
     }
 
-    private fun <T> HueResponse<T>.extractData(type: String): Mono<List<T>> =
+    private fun <T> HueResponse<T>.extractData(type: String): List<T> =
         if (errors.isNotEmpty()) {
             val message = errors.joinToString(separator = "\n") { it.description }
             logger.warn { "Retrieve Hue $type... failed: $message" }
-            Mono.error(ObservationException(message))
+            throw ObservationException(message)
         } else {
             logger.info { "Retrieve Hue $type... OK, ${data.size} found" }
-            Mono.just(data)
+            data
         }
 
     companion object {

--- a/src/main/kotlin/com/larastudios/chambrier/adapter/hue/sse/MapLightChanged.kt
+++ b/src/main/kotlin/com/larastudios/chambrier/adapter/hue/sse/MapLightChanged.kt
@@ -24,7 +24,7 @@ fun mapChangedLightProperty(property: ChangedLightProperty): Sequence<Event> = s
         yield(ColorPropertyChanged(property.owner.rid, "color", xy, gamut))
     }
 
-    if (property.colorTemperature != null) {
+    if (property.colorTemperature != null && property.colorTemperature.mirekValid) {
         yield(NumberPropertyChanged(property.owner.rid, "colorTemperature", mirekToKelvin(property.colorTemperature.mirek)))
     }
 }

--- a/src/main/kotlin/com/larastudios/chambrier/app/AppListener.kt
+++ b/src/main/kotlin/com/larastudios/chambrier/app/AppListener.kt
@@ -28,7 +28,9 @@ class AppListener(
         val flows = flowLoader.load()
 
         launch(CoroutineName("storeListener")) {
-            store.state().asFlow()
+            store.state()
+                .log()
+                .asFlow()
                 .collect { state ->
                     val commands = flows.map { flowEngine.execute(it, FlowContext(state)) }
                         .map {
@@ -54,8 +56,6 @@ class AppListener(
 
         store.subscribe(events)
         logger.info { "Store subscribed to event stream" }
-
-        store.state().log().subscribe()
     }
 
     companion object {

--- a/src/main/kotlin/com/larastudios/chambrier/app/AppListener.kt
+++ b/src/main/kotlin/com/larastudios/chambrier/app/AppListener.kt
@@ -9,8 +9,6 @@ import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.reactive.asFlow
-import kotlinx.coroutines.reactor.asFlux
 import org.springframework.context.event.ContextRefreshedEvent
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component
@@ -29,9 +27,8 @@ class AppListener(
 
         launch(CoroutineName("storeListener")) {
             store.state()
-                .log()
-                .asFlow()
                 .collect { state ->
+                    logger.info { "[storeListener] $state" }
                     val commands = flows.map { flowEngine.execute(it, FlowContext(state)) }
                         .map {
                             getCommandMap(it.scope)
@@ -52,7 +49,7 @@ class AppListener(
             logger.info { "Starting ${it::class.simpleName}" }
             it.observe()
         }.merge()
-        store.subscribe(eventFlow.asFlux())
+        store.subscribe(eventFlow)
 
         logger.info { "Store subscribed to event stream" }
     }

--- a/src/main/kotlin/com/larastudios/chambrier/app/AppListener.kt
+++ b/src/main/kotlin/com/larastudios/chambrier/app/AppListener.kt
@@ -5,6 +5,7 @@ import com.larastudios.chambrier.app.domain.FlowContext
 import com.larastudios.chambrier.app.flowEngine.ControlDeviceAction
 import com.larastudios.chambrier.app.flowEngine.FlowEngine
 import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.runBlocking
 import org.springframework.context.ApplicationListener
 import org.springframework.context.event.ContextRefreshedEvent
 import org.springframework.stereotype.Component
@@ -20,6 +21,12 @@ class AppListener(
     val flowEngine: FlowEngine
 ) : ApplicationListener<ContextRefreshedEvent> {
     override fun onApplicationEvent(event: ContextRefreshedEvent) {
+        runBlocking {
+            contextRefreshed()
+        }
+    }
+
+    suspend fun contextRefreshed() {
         val flows = flowLoader.load()
 
         store.state()

--- a/src/main/kotlin/com/larastudios/chambrier/app/AppListener.kt
+++ b/src/main/kotlin/com/larastudios/chambrier/app/AppListener.kt
@@ -5,9 +5,9 @@ import com.larastudios.chambrier.app.domain.FlowContext
 import com.larastudios.chambrier.app.flowEngine.ControlDeviceAction
 import com.larastudios.chambrier.app.flowEngine.FlowEngine
 import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlinx.coroutines.runBlocking
-import org.springframework.context.ApplicationListener
+import kotlinx.coroutines.coroutineScope
 import org.springframework.context.event.ContextRefreshedEvent
+import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component
 import reactor.core.publisher.Flux
 import reactor.core.scheduler.Schedulers
@@ -19,14 +19,9 @@ class AppListener(
     val store: Store,
     val flowLoader: FlowLoader,
     val flowEngine: FlowEngine
-) : ApplicationListener<ContextRefreshedEvent> {
-    override fun onApplicationEvent(event: ContextRefreshedEvent) {
-        runBlocking {
-            contextRefreshed()
-        }
-    }
-
-    suspend fun contextRefreshed() {
+) {
+    @EventListener
+    suspend fun handleContextRefreshEvent(event: ContextRefreshedEvent): Unit = coroutineScope {
         val flows = flowLoader.load()
 
         store.state()

--- a/src/main/kotlin/com/larastudios/chambrier/app/AppListener.kt
+++ b/src/main/kotlin/com/larastudios/chambrier/app/AppListener.kt
@@ -5,7 +5,10 @@ import com.larastudios.chambrier.app.domain.FlowContext
 import com.larastudios.chambrier.app.flowEngine.ControlDeviceAction
 import com.larastudios.chambrier.app.flowEngine.FlowEngine
 import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.*
+import kotlinx.coroutines.reactive.asFlow
+import org.springframework.context.ApplicationListener
+import org.springframework.context.event.ContextClosedEvent
 import org.springframework.context.event.ContextRefreshedEvent
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component
@@ -24,22 +27,24 @@ class AppListener(
     suspend fun handleContextRefreshEvent(event: ContextRefreshedEvent): Unit = coroutineScope {
         val flows = flowLoader.load()
 
-        store.state()
-            .doOnNext { state ->
-                val commands = flows.map { flowEngine.execute(it, FlowContext(state)) }
-                    .map {
-                        getCommandMap(it.scope)
-                    }
-                    .fold(mapOf(), ::mergeCommandMaps)
-                    .map { (deviceId, propertyMap) ->
-                        val device = state.devices[deviceId] ?: throw IllegalArgumentException("State contains no device with id '$deviceId'")
-                        ControlDeviceCommand(device, propertyMap)
-                    }
+        launch(CoroutineName("storeListener")) {
+            store.state().asFlow()
+                .collect { state ->
+                    val commands = flows.map { flowEngine.execute(it, FlowContext(state)) }
+                        .map {
+                            getCommandMap(it.scope)
+                        }
+                        .fold(mapOf(), ::mergeCommandMaps)
+                        .map { (deviceId, propertyMap) ->
+                            val device = state.devices[deviceId] ?: throw IllegalArgumentException("State contains no device with id '$deviceId'")
+                            ControlDeviceCommand(device, propertyMap)
+                        }
 
-                controllers.forEach {
-                    it.send(commands)
+                    controllers.forEach {
+                        it.send(commands)
+                    }
                 }
-            }.subscribe()
+        }
 
         val events = Flux.merge(
             observers.map {

--- a/src/main/kotlin/com/larastudios/chambrier/app/Controller.kt
+++ b/src/main/kotlin/com/larastudios/chambrier/app/Controller.kt
@@ -3,5 +3,5 @@ package com.larastudios.chambrier.app
 import com.larastudios.chambrier.app.domain.DeviceCommand
 
 interface Controller {
-    fun send(commands: List<DeviceCommand>)
+    suspend fun send(commands: List<DeviceCommand>)
 }

--- a/src/main/kotlin/com/larastudios/chambrier/app/FlowLoader.kt
+++ b/src/main/kotlin/com/larastudios/chambrier/app/FlowLoader.kt
@@ -3,7 +3,7 @@ package com.larastudios.chambrier.app
 import com.larastudios.chambrier.app.flowEngine.Flow
 
 interface FlowLoader {
-    fun load(): List<Flow>
+    suspend fun load(): List<Flow>
 }
 
 class FlowLoadException(override val message: String?) : Exception(message)

--- a/src/main/kotlin/com/larastudios/chambrier/app/Observer.kt
+++ b/src/main/kotlin/com/larastudios/chambrier/app/Observer.kt
@@ -1,8 +1,8 @@
 package com.larastudios.chambrier.app
 
 import com.larastudios.chambrier.app.domain.Event
-import reactor.core.publisher.Flux
+import kotlinx.coroutines.flow.Flow
 
 interface Observer {
-    fun observe(): Flux<Event>
+    suspend fun observe(): Flow<Event>
 }

--- a/src/main/kotlin/com/larastudios/chambrier/app/flowEngine/Actions.kt
+++ b/src/main/kotlin/com/larastudios/chambrier/app/flowEngine/Actions.kt
@@ -7,15 +7,15 @@ import com.larastudios.chambrier.app.domain.isAssignableTo
 import io.github.oshai.kotlinlogging.KotlinLogging
 
 interface Action {
-    fun execute(context: Context, scope: Scope)
+    suspend fun execute(context: Context, scope: Scope)
 }
 
 data object DoNothingAction : Action {
-    override fun execute(context: Context, scope: Scope) {}
+    override suspend fun execute(context: Context, scope: Scope) {}
 }
 
 data class LogAction(val message: String) : Action {
-    override fun execute(context: Context, scope: Scope) {
+    override suspend fun execute(context: Context, scope: Scope) {
         logger.info { message }
     }
 
@@ -25,7 +25,7 @@ data class LogAction(val message: String) : Action {
 }
 
 data class ControlDeviceAction(val deviceId: String, val propertyMap: Map<String, PropertyValue>) : Action {
-    override fun execute(context: Context, scope: Scope) {
+    override suspend fun execute(context: Context, scope: Scope) {
         val state = (context as FlowContext).state
         val device = state.devices[deviceId]
         if (device == null) {

--- a/src/main/kotlin/com/larastudios/chambrier/app/flowEngine/FlowEngine.kt
+++ b/src/main/kotlin/com/larastudios/chambrier/app/flowEngine/FlowEngine.kt
@@ -1,5 +1,5 @@
 package com.larastudios.chambrier.app.flowEngine
 
 interface FlowEngine {
-    fun execute(flow: Flow, context: Context): ExecutedFlowReport
+    suspend fun execute(flow: Flow, context: Context): ExecutedFlowReport
 }

--- a/src/main/kotlin/com/larastudios/chambrier/app/flowEngine/RiverEngine.kt
+++ b/src/main/kotlin/com/larastudios/chambrier/app/flowEngine/RiverEngine.kt
@@ -6,7 +6,7 @@ import java.time.Duration
 
 @Service
 class RiverEngine : FlowEngine {
-    override fun execute(flow: Flow, context: Context): ExecutedFlowReport {
+    override suspend fun execute(flow: Flow, context: Context): ExecutedFlowReport {
         logger.debug { "Executing flow ${flow.name}..." }
         val start = System.currentTimeMillis()
 
@@ -18,7 +18,7 @@ class RiverEngine : FlowEngine {
         return ExecutedFlowReport(scope.data, Duration.ofMillis(durationInMs))
     }
 
-    private tailrec fun executeNode(node: FlowNode, context: Context, scope: Scope) {
+    private tailrec suspend fun executeNode(node: FlowNode, context: Context, scope: Scope) {
         val nextNode = when (node) {
             is ActionFlowNode -> {
                 logger.debug { "Executing action ${node.action::class.simpleName}" }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -10,6 +10,15 @@ spring:
   codec:
     max-in-memory-size: 1MB
 
+resilience4j.ratelimiter:
+  instances:
+    hue:
+      limitForPeriod: 1
+      limitRefreshPeriod: 100ms
+      timeoutDuration: 200ms
+      registerHealthIndicator: true
+      eventConsumerBufferSize: 100
+
 flows:
   directory: /etc/chambrier/flows
 

--- a/src/test/kotlin/com/larastudios/chambrier/app/flowEngine/ControlDeviceActionTest.kt
+++ b/src/test/kotlin/com/larastudios/chambrier/app/flowEngine/ControlDeviceActionTest.kt
@@ -5,6 +5,7 @@ import com.larastudios.chambrier.initialState
 import com.larastudios.chambrier.lightDevice
 import com.larastudios.chambrier.lightDevice2
 import com.larastudios.chambrier.switchDevice
+import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -18,7 +19,7 @@ class ControlDeviceActionTest {
     private val context = FlowContext(state = initialState)
 
     @Test
-    fun `does not modify the scope if the device is unknown `() {
+    fun `does not modify the scope if the device is unknown `() = runTest {
         val scope = Scope()
 
         action.execute(FlowContext(State(mapOf())), scope)
@@ -27,7 +28,7 @@ class ControlDeviceActionTest {
     }
 
     @Test
-    fun `ignores all properties if the device is known but all properties are unknown`() {
+    fun `ignores all properties if the device is known but all properties are unknown`() = runTest {
         val scope = Scope()
 
         val action = ControlDeviceAction(lightDevice.id, mapOf("unknownProperty" to SetBooleanValue(true)))
@@ -37,7 +38,7 @@ class ControlDeviceActionTest {
     }
 
     @Test
-    fun `ignores valid properties that are read-only`() {
+    fun `ignores valid properties that are read-only`() = runTest {
         val scope = Scope()
 
         val action = ControlDeviceAction(switchDevice.id, mapOf("button1" to SetEnumValue(HueButtonState.ShortRelease)))
@@ -47,7 +48,7 @@ class ControlDeviceActionTest {
     }
 
     @Test
-    fun `adds the known properties while ignoring unknown properties`() {
+    fun `adds the known properties while ignoring unknown properties`() = runTest {
         val scope = Scope()
 
         val action = ControlDeviceAction(lightDevice.id, mapOf("unknownProperty" to SetBooleanValue(true)) + property)
@@ -58,7 +59,7 @@ class ControlDeviceActionTest {
     }
 
     @Test
-    fun `adds the deviceId and properties if the command map is absent from the scope`() {
+    fun `adds the deviceId and properties if the command map is absent from the scope`() = runTest {
         val scope = Scope()
 
         action.execute(context, scope)
@@ -68,7 +69,7 @@ class ControlDeviceActionTest {
     }
 
     @Test
-    fun `adds the deviceId and properties if the command map contains another deviceId`() {
+    fun `adds the deviceId and properties if the command map contains another deviceId`() = runTest {
         val scope = Scope(data = mutableMapOf(ControlDeviceAction.COMMAND_MAP to mutableMapOf(lightDevice2.id to property)))
 
         action.execute(context, scope)
@@ -83,7 +84,7 @@ class ControlDeviceActionTest {
     }
 
     @Test
-    fun `adds the properties if the command map contains the deviceId but with different properties`() {
+    fun `adds the properties if the command map contains the deviceId but with different properties`() = runTest {
         val scope = Scope(data = mutableMapOf(ControlDeviceAction.COMMAND_MAP to mutableMapOf(lightDevice.id to propertyTwo)))
 
         action.execute(context, scope)
@@ -100,7 +101,7 @@ class ControlDeviceActionTest {
     }
 
     @Test
-    fun `overwrites existing properties if the command map contains the deviceId and properties`() {
+    fun `overwrites existing properties if the command map contains the deviceId and properties`() = runTest {
         val scope = Scope(data = mutableMapOf(ControlDeviceAction.COMMAND_MAP to mutableMapOf(lightDevice.id to propertyTwo)))
 
         action.execute(context, scope)
@@ -117,7 +118,7 @@ class ControlDeviceActionTest {
     }
 
     @Test
-    fun `overwrites existing properties and adds new properties`() {
+    fun `overwrites existing properties and adds new properties`() = runTest {
         val scope = Scope(data = mutableMapOf(ControlDeviceAction.COMMAND_MAP to mutableMapOf(lightDevice.id to property)))
 
         val action = ControlDeviceAction(lightDevice.id, propertyTwo + propertyThree)


### PR DESCRIPTION
Use coroutines instead of Reactor to simplify the code and make debugging easier. This enables an easy way to implement timers and delays in flows by suspending the execution.
